### PR TITLE
Set up dev environment + add Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this is
+"100 Grams" is an **Expo (React Native) mobile app** that scans food barcodes, fetches
+nutrition data from the Open Food Facts API, and compares products normalized to 100 g.
+There is a single app; no backend service.
+
+### Running it in the cloud VM
+- There is no mobile device/emulator here, so run the **web** target: `npx expo start --web`
+  (serves on http://localhost:8081 via Metro + `react-native-web`). `npm run android` / `npm run ios`
+  are not usable in this environment.
+- Dependencies are installed with **npm** (`package-lock.json`). The startup update script runs `npm install`.
+
+### Lint / typecheck / tests
+- Lint: `npm run lint` (a.k.a. `npx expo lint`). Passes with only warnings; treat warnings as non-blocking.
+- There is **no test script** and no test framework configured.
+- `npx tsc --noEmit` reports several **pre-existing** type errors (e.g. `responsiveOrientation`,
+  `ScrollView vertical`, `hitSlop` on styles). These are not part of any repo script; Metro/Babel bundles
+  the app regardless and it runs fine. Do not treat these as environment breakage.
+
+### Camera gating (important gotcha for web testing)
+- The home/scan screen and the comparison **detail** screen both gate their UI behind
+  `Camera.requestCameraPermissionsAsync()`. On web this calls `getUserMedia({video:true})`, so with **no
+  camera device the status is "denied"** and those screens render "No access to camera".
+- To exercise the full app on web, launch Chrome with a fake camera so permission is granted:
+  `google-chrome --use-fake-device-for-media-stream --use-fake-ui-for-media-stream --user-data-dir=/tmp/chrome-fakecam http://localhost:8081`
+- The **History list** screen (`app/(tabs)/history/index.tsx`) does not require the camera and works regardless.
+
+### Data & network
+- Persistence uses `@react-native-async-storage/async-storage`, which on web maps to `window.localStorage`
+  with the raw key. Saved comparisons live under the `comparisons` key; you can seed/inspect them via the
+  browser console (e.g. `localStorage.setItem('comparisons', ...)`).
+- Barcode scanning fetches from `https://world.openfoodfacts.org/api/v0/product/<barcode>.json` and needs
+  outbound network access.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for the **100 Grams** Expo (React Native) app and documents durable cloud-agent notes in `AGENTS.md`.

- Startup update script: `npm install` (matches `package-lock.json`).
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: running the web target, lint/typecheck notes, the camera-permission gotcha on web, and how AsyncStorage/localStorage + Open Food Facts are used.

No application code was modified.

## Verification
- ✅ `npm install`
- ✅ `npm run lint` (`expo lint`) — 0 errors (warnings only)
- ✅ `npx expo start --web` — bundles and serves at `http://localhost:8081` (HTTP 200)
- ⚠️ `npx tsc --noEmit` — pre-existing type errors (not a repo script; Metro/Babel bundles fine)

Ran the core flow end-to-end on unmodified code (Chrome launched with a fake camera so the app's camera-gated screens render): seeded a real Nutella vs Coca-Cola comparison, opened the comparison detail (nutrition per 100 g), and re-sorted by Calories and Protein.

[100grams_nutrition_comparison_demo.mp4](https://cursor.com/agents/bc-2491da3e-214c-4318-a34b-2af0c7ef5c30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F100grams_nutrition_comparison_demo.mp4)

[Comparison detail table (per 100g)](https://cursor.com/agents/bc-2491da3e-214c-4318-a34b-2af0c7ef5c30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomparison_detail_table.webp)
[Home scanner view with fake camera](https://cursor.com/agents/bc-2491da3e-214c-4318-a34b-2af0c7ef5c30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_scanner_view.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2491da3e-214c-4318-a34b-2af0c7ef5c30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2491da3e-214c-4318-a34b-2af0c7ef5c30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

